### PR TITLE
Adding function to `join` multiple `TSFrame`s.

### DIFF
--- a/src/join.jl
+++ b/src/join.jl
@@ -81,7 +81,6 @@ julia> random(x) = rand(MersenneTwister(123), x);
 julia> dates = collect(Date(2017,1,1):Day(1):Date(2017,1,10));
 
 julia> ts1 = TSFrame(random(length(dates)), dates);
-
 julia> show(ts1)
 (10 x 1) TSFrame with Dates.Date Index
 
@@ -290,10 +289,6 @@ julia> join(ts1, ts2, ts3; jointype=JoinLeft)
 
 ```
 """
-function Base.join(ts1::TSFrame, ts2::TSFrame)
-    join(ts1, ts2, JoinAll)
-end
-
 function Base.join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinBoth})
     result = DataFrames.innerjoin(ts1.coredata, ts2.coredata, on=:Index, makeunique=true)
     return TSFrame(result)
@@ -320,7 +315,7 @@ function Base.join(
     ts1::TSFrame,
     ts2::TSFrame,
     ts...;
-    jointype::T
+    jointype::T=JoinAll
 ) where {
     T <:
     Union{

--- a/src/join.jl
+++ b/src/join.jl
@@ -247,5 +247,29 @@ function Base.join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinRight})
     result = DataFrames.rightjoin(ts1.coredata, ts2.coredata, on=:Index, makeunique=true)
     return TSFrame(result)
 end
+
+function Base.join(
+    ts1::TSFrame,
+    ts2::TSFrame,
+    ts...;
+    jointype::T
+) where {
+    T <:
+    Union{
+        Type{JoinAll},
+        Type{JoinBoth},
+        Type{JoinInner},
+        Type{JoinOuter},
+        Type{JoinLeft},
+        Type{JoinRight}
+    }
+}
+    if isempty(ts)
+        return Base.join(ts1, ts2, jointype)
+    else
+        return Base.join(Base.join(ts1, ts2, jointype), ts...; jointype=jointype)
+    end
+end
+
 # alias
 cbind = join

--- a/src/join.jl
+++ b/src/join.jl
@@ -65,7 +65,7 @@ is provided to the `join` method.
 
 Joining multiple `TSFrame`s is also supported. The syntax is
 
-`join(ts1::TSFrame, ts2::TSFrame, ts...; on::T)`
+`join(ts1::TSFrame, ts2::TSFrame, ts...; jointype::T)`
 
 where `T <: Union{Type{JoinAll}, Type{JoinBoth}, Type{JoinInner}, Type{JoinOuter}, Type{JoinLeft}, Type{JoinRight}}`.
 Note that `join` on multiple `TSFrame`s is left associative.
@@ -260,7 +260,7 @@ julia> ts3 = TSFrame(random(length(dates)), dates)
          8 rows omitted
 
 # joining multiple TSFrame objects
-julia> join(ts1, ts2, ts3; on=JoinLeft)
+julia> join(ts1, ts2, ts3; jointype=JoinLeft)
 10×3 TSFrame with Date Index
  Index       x1         x1_1       x1_2
  Date        Float64    Float64?   Float64?
@@ -308,7 +308,7 @@ function Base.join(
     ts1::TSFrame,
     ts2::TSFrame,
     ts...;
-    on::T
+    jointype::T
 ) where {
     T <:
     Union{
@@ -321,9 +321,9 @@ function Base.join(
     }
 }
     if isempty(ts)
-        return Base.join(ts1, ts2, on)
+        return Base.join(ts1, ts2, jointype)
     else
-        return Base.join(Base.join(ts1, ts2, on), ts...; on=on)
+        return Base.join(Base.join(ts1, ts2, jointype), ts...; jointype=jointype)
     end
 end
 

--- a/src/join.jl
+++ b/src/join.jl
@@ -63,6 +63,13 @@ object.
 The default behaviour is to assume `JoinAll` if no `JoinType` object
 is provided to the `join` method.
 
+Joining multiple `TSFrame`s is also supported. The syntax is
+
+`join(ts1::TSFrame, ts2::TSFrame, ts...; jointype::T)`
+
+where `T <: Union{Type{JoinAll}, Type{JoinBoth}, Type{JoinInner}, Type{JoinOuter}, Type{JoinLeft}, Type{JoinRight}}`.
+Note that `join` on multiple `TSFrame`s is left associative.
+
 `cbind` is an alias for `join` method.
 
 # Examples
@@ -73,7 +80,7 @@ julia> random(x) = rand(MersenneTwister(123), x);
 
 julia> dates = collect(Date(2017,1,1):Day(1):Date(2017,1,10));
 
-julia> ts1 = TSFrame(random(length(dates)), dates)
+julia> ts1 = TSFrame(random(length(dates)), dates);
 julia> show(ts1)
 (10 x 1) TSFrame with Dates.Date Index
 
@@ -219,6 +226,55 @@ julia> join(ts1, ts2, JoinRight)
  2017-01-29  missing          0.555668
  2017-01-30  missing          0.940782
                          11 rows omitted
+
+julia> dates = collect(Date(2017,1,1):Day(1):Date(2017,1,30));
+
+julia> ts3 = TSFrame(random(length(dates)), dates)
+30×1 TSFrame with Date Index
+ Index       x1
+ Date        Float64
+───────────────────────
+ 2017-01-01  0.768448
+ 2017-01-02  0.940515
+ 2017-01-03  0.673959
+ 2017-01-04  0.395453
+ 2017-01-05  0.313244
+ 2017-01-06  0.662555
+ 2017-01-07  0.586022
+ 2017-01-08  0.0521332
+ 2017-01-09  0.26864
+ 2017-01-10  0.108871
+ 2017-01-11  0.163666
+     ⋮           ⋮
+ 2017-01-20  0.255981
+ 2017-01-21  0.70586
+ 2017-01-22  0.291978
+ 2017-01-23  0.281066
+ 2017-01-24  0.792931
+ 2017-01-25  0.20923
+ 2017-01-26  0.918165
+ 2017-01-27  0.614255
+ 2017-01-28  0.802665
+ 2017-01-29  0.555668
+ 2017-01-30  0.940782
+         8 rows omitted
+
+# joining multiple TSFrame objects
+julia> join(ts1, ts2, ts3; jointype=JoinLeft)
+10×3 TSFrame with Date Index
+ Index       x1         x1_1       x1_2
+ Date        Float64    Float64?   Float64?
+─────────────────────────────────────────────
+ 2017-01-01  0.768448   0.768448   0.768448
+ 2017-01-02  0.940515   0.940515   0.940515
+ 2017-01-03  0.673959   0.673959   0.673959
+ 2017-01-04  0.395453   0.395453   0.395453
+ 2017-01-05  0.313244   0.313244   0.313244
+ 2017-01-06  0.662555   0.662555   0.662555
+ 2017-01-07  0.586022   0.586022   0.586022
+ 2017-01-08  0.0521332  0.0521332  0.0521332
+ 2017-01-09  0.26864    0.26864    0.26864
+ 2017-01-10  0.108871   0.108871   0.108871
 
 ```
 """

--- a/src/join.jl
+++ b/src/join.jl
@@ -24,8 +24,8 @@ column names amongst the TSFrame objects.
 
 The following join types are supported:
 
-`join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinInner})` and
-`join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinBoth})`
+`join(ts1::TSFrame, ts2::TSFrame; jointype::Type{JoinInner})` and
+`join(ts1::TSFrame, ts2::TSFrame; jointype::Type{JoinBoth})`
 
 a.k.a. inner join, takes the intersection of the indexes of `ts1` and
 `ts2`, and then merges the columns of both the objects. The resulting
@@ -33,8 +33,8 @@ object will only contain rows which are present in both the objects'
 indexes. The function will rename columns in the final object if
 they had same names in the TSFrame objects.
 
-`join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinOuter})` and
-`join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinAll})`:
+`join(ts1::TSFrame, ts2::TSFrame; jointype::Type{JoinOuter})` and
+`join(ts1::TSFrame, ts2::TSFrame; jointype::Type{JoinAll})`:
 
 a.k.a. outer join, takes the union of the indexes of `ts1` and `ts2`
 before merging the other columns of input objects. The output will
@@ -43,7 +43,7 @@ inserting `missing` values where a row was not present in any of the
 objects. This is the default behaviour if no `JoinType` object is
 provided.
 
-`join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinLeft})`:
+`join(ts1::TSFrame, ts2::TSFrame; jointype::Type{JoinLeft})`:
 
 Left join takes the index values which are present in the left
 object `ts1` and finds matching index values in the right object
@@ -53,7 +53,7 @@ associated with matching index rows on the right. The operation
 inserts `missing` values where in the unmatched rows of the right
 object.
 
-`join(ts1::TSFrame, ts2::TSFrame, ::Type{JoinRight})`
+`join(ts1::TSFrame, ts2::TSFrame; jointype::Type{JoinRight})`
 
 Right join, similar to left join but works in the opposite
 direction. The final object contains all the rows from the right
@@ -81,6 +81,7 @@ julia> random(x) = rand(MersenneTwister(123), x);
 julia> dates = collect(Date(2017,1,1):Day(1):Date(2017,1,10));
 
 julia> ts1 = TSFrame(random(length(dates)), dates);
+
 julia> show(ts1)
 (10 x 1) TSFrame with Dates.Date Index
 
@@ -102,8 +103,7 @@ julia> dates = collect(Date(2017,1,1):Day(1):Date(2017,1,30));
 
 julia> ts2 = TSFrame(random(length(dates)), dates);
 julia> show(ts2)
-(30 x 1) TSFrame with Dates.Date Index
-
+30×1 TSFrame with Date Index
  Index       x1
  Date        Float64
 ───────────────────────
@@ -115,7 +115,20 @@ julia> show(ts2)
  2017-01-06  0.662555
  2017-01-07  0.586022
  2017-01-08  0.0521332
-     ⋮           ⋮
+ 2017-01-09  0.26864
+ 2017-01-10  0.108871
+ 2017-01-11  0.163666
+ 2017-01-12  0.473017
+ 2017-01-13  0.865412
+ 2017-01-14  0.617492
+ 2017-01-15  0.285698
+ 2017-01-16  0.463847
+ 2017-01-17  0.275819
+ 2017-01-18  0.446568
+ 2017-01-19  0.582318
+ 2017-01-20  0.255981
+ 2017-01-21  0.70586
+ 2017-01-22  0.291978
  2017-01-23  0.281066
  2017-01-24  0.792931
  2017-01-25  0.20923
@@ -124,14 +137,11 @@ julia> show(ts2)
  2017-01-28  0.802665
  2017-01-29  0.555668
  2017-01-30  0.940782
-        14 rows omitted
-
 
 # join on all index values
-# equivalent to `join(ts1, ts2, JoinAll)` call
+# equivalent to `join(ts1, ts2; jointype=JoinAll)` call
 julia> join(ts1, ts2)
 (30 x 2) TSFrame with Date Index
-
  Index       x1               x1_1
  Date        Float64?         Float64?
 ────────────────────────────────────────
@@ -161,9 +171,8 @@ julia> join(ts1, ts2)
 julia> cbind(ts1, ts2);
 
 # join only the common index values
-julia> join(ts1, ts2, JoinBoth)
+julia> join(ts1, ts2; jointype=JoinBoth)
 (10 x 2) TSFrame with Date Index
-
  Index       x1         x1_1
  Date        Float64    Float64
 ──────────────────────────────────
@@ -178,11 +187,9 @@ julia> join(ts1, ts2, JoinBoth)
  2017-01-09  0.26864    0.26864
  2017-01-10  0.108871   0.108871
 
-
 # keep index values of `ts1`
-julia> join(ts1, ts2, JoinLeft)
+julia> join(ts1, ts2; jointype=JoinLeft)
 (10 x 2) TSFrame with Date Index
-
  Index       x1         x1_1
  Date        Float64    Float64?
 ──────────────────────────────────
@@ -197,11 +204,9 @@ julia> join(ts1, ts2, JoinLeft)
  2017-01-09  0.26864    0.26864
  2017-01-10  0.108871   0.108871
 
-
 # keep index values of `ts2`
-julia> join(ts1, ts2, JoinRight)
+julia> join(ts1, ts2; jointype=JoinRight)
 (30 x 2) TSFrame with Date Index
-
  Index       x1               x1_1
  Date        Float64?         Float64
 ────────────────────────────────────────
@@ -229,7 +234,8 @@ julia> join(ts1, ts2, JoinRight)
 
 julia> dates = collect(Date(2017,1,1):Day(1):Date(2017,1,30));
 
-julia> ts3 = TSFrame(random(length(dates)), dates)
+julia> ts3 = TSFrame(random(length(dates)), dates);
+julia> show(ts3)
 30×1 TSFrame with Date Index
  Index       x1
  Date        Float64
@@ -245,7 +251,14 @@ julia> ts3 = TSFrame(random(length(dates)), dates)
  2017-01-09  0.26864
  2017-01-10  0.108871
  2017-01-11  0.163666
-     ⋮           ⋮
+ 2017-01-12  0.473017
+ 2017-01-13  0.865412
+ 2017-01-14  0.617492
+ 2017-01-15  0.285698
+ 2017-01-16  0.463847
+ 2017-01-17  0.275819
+ 2017-01-18  0.446568
+ 2017-01-19  0.582318
  2017-01-20  0.255981
  2017-01-21  0.70586
  2017-01-22  0.291978
@@ -257,7 +270,6 @@ julia> ts3 = TSFrame(random(length(dates)), dates)
  2017-01-28  0.802665
  2017-01-29  0.555668
  2017-01-30  0.940782
-         8 rows omitted
 
 # joining multiple TSFrame objects
 julia> join(ts1, ts2, ts3; jointype=JoinLeft)

--- a/src/join.jl
+++ b/src/join.jl
@@ -65,7 +65,7 @@ is provided to the `join` method.
 
 Joining multiple `TSFrame`s is also supported. The syntax is
 
-`join(ts1::TSFrame, ts2::TSFrame, ts...; jointype::T)`
+`join(ts1::TSFrame, ts2::TSFrame, ts...; on::T)`
 
 where `T <: Union{Type{JoinAll}, Type{JoinBoth}, Type{JoinInner}, Type{JoinOuter}, Type{JoinLeft}, Type{JoinRight}}`.
 Note that `join` on multiple `TSFrame`s is left associative.
@@ -260,7 +260,7 @@ julia> ts3 = TSFrame(random(length(dates)), dates)
          8 rows omitted
 
 # joining multiple TSFrame objects
-julia> join(ts1, ts2, ts3; jointype=JoinLeft)
+julia> join(ts1, ts2, ts3; on=JoinLeft)
 10×3 TSFrame with Date Index
  Index       x1         x1_1       x1_2
  Date        Float64    Float64?   Float64?
@@ -308,7 +308,7 @@ function Base.join(
     ts1::TSFrame,
     ts2::TSFrame,
     ts...;
-    jointype::T
+    on::T
 ) where {
     T <:
     Union{
@@ -321,9 +321,9 @@ function Base.join(
     }
 }
     if isempty(ts)
-        return Base.join(ts1, ts2, jointype)
+        return Base.join(ts1, ts2, on)
     else
-        return Base.join(Base.join(ts1, ts2, jointype), ts...; jointype=jointype)
+        return Base.join(Base.join(ts1, ts2, on), ts...; on=on)
     end
 end
 

--- a/test/join.jl
+++ b/test/join.jl
@@ -1,5 +1,6 @@
 ts1 = TSFrame(rand(DATA_SIZE), index_timetype)
 ts2 = TSFrame(rand(Int(floor(DATA_SIZE/2))), index_timetype[1:Int(floor(DATA_SIZE/2))])
+ts3 = TSFrame(rand(DATA_SIZE), index_timetype)
 
 # testing JoinInner/JoinBoth
 ts_innerjoin = join(ts1, ts2, JoinInner)
@@ -14,6 +15,20 @@ ts_joinboth = join(ts1, ts2, JoinBoth)
 @test ts_joinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
+ts_multipleinnerjoin = join(ts1, ts2, ts3; jointype=JoinInner)
+@test propertynames(ts_multipleinnerjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
+@test ts_multipleinnerjoin[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
+@test ts_multipleinnerjoin[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multipleinnerjoin[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multipleinnerjoin[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
+
+ts_multiplejoinboth = join(ts1, ts2, ts3; jointype=JoinBoth)
+@test propertynames(ts_multiplejoinboth.coredata) == [:Index, :x1, :x1_1, :x1_2]
+@test ts_multiplejoinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
+@test ts_multiplejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multiplejoinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multiplejoinboth[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
+
 # testing JoinOuter/JoinAll
 ts_outerjoin = join(ts1, ts2, JoinOuter)
 @test propertynames(ts_outerjoin.coredata) == [:Index, :x1, :x1_1]
@@ -22,12 +37,28 @@ ts_outerjoin = join(ts1, ts2, JoinOuter)
 @test ts_outerjoin[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_outerjoin[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_joinboth = join(ts1, ts2, JoinAll)
-@test propertynames(ts_joinboth.coredata) == [:Index, :x1, :x1_1]
-@test ts_joinboth[:, :Index] == ts1[1:DATA_SIZE, :Index]
-@test ts_joinboth[:, :x1] == ts1[1:DATA_SIZE, :x1]
-@test ts_joinboth[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
-@test isequal(Vector{Missing}(ts_joinboth[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+ts_joinall = join(ts1, ts2, JoinAll)
+@test propertynames(ts_joinall.coredata) == [:Index, :x1, :x1_1]
+@test ts_joinall[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_joinall[:, :x1] == ts1[1:DATA_SIZE, :x1]
+@test ts_joinall[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test isequal(Vector{Missing}(ts_joinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+
+ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=JoinOuter)
+@test propertynames(ts_multipleouterjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
+@test ts_multipleouterjoin[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_multipleouterjoin[:, :x1] == ts1[1:DATA_SIZE, :x1]
+@test ts_multipleouterjoin[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multipleouterjoin[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test isequal(Vector{Missing}(ts_multipleouterjoin[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+
+ts_multiplejoinall = join(ts1, ts2, ts3; jointype=JoinAll)
+@test propertynames(ts_multiplejoinall.coredata) == [:Index, :x1, :x1_1, :x1_2]
+@test ts_multiplejoinall[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_multiplejoinall[:, :x1] == ts1[1:DATA_SIZE, :x1]
+@test ts_multiplejoinall[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multiplejoinall[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test isequal(Vector{Missing}(ts_multiplejoinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
 # testing JoinLeft
 ts_joinleft = join(ts1, ts2, JoinLeft)
@@ -37,9 +68,26 @@ ts_joinleft = join(ts1, ts2, JoinLeft)
 @test ts_joinleft[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
+ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=JoinLeft)
+@test propertynames(ts_multiplejoinleft.coredata) == [:Index, :x1, :x1_1, :x1_2]
+@test ts_multiplejoinleft[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_multiplejoinleft[:, :x1] == ts1[1:DATA_SIZE, :x1]
+@test ts_multiplejoinleft[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_multiplejoinleft[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test isequal(Vector{Missing}(ts_multiplejoinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+
 # testing JoinRight
 ts_joinright = join(ts1, ts2, JoinRight)
 @test propertynames(ts_joinright.coredata) == [:Index, :x1, :x1_1]
 @test ts_joinright[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_joinright[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinright[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+
+ts_multiplejoinright = join(ts1, ts2, ts3; jointype=JoinRight)
+@test propertynames(ts_multiplejoinright.coredata) == [:Index, :x1, :x1_1, :x1_2]
+@test ts_multiplejoinright[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_multiplejoinright[1:Int(floor(DATA_SIZE/2)), :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
+@test isequal(Vector{Missing}(ts_multiplejoinright[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+@test ts_multiplejoinright[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test isequal(Vector{Missing}(ts_multiplejoinright[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+@test ts_multiplejoinright[:, :x1_2] == ts3[1:DATA_SIZE, :x1]

--- a/test/join.jl
+++ b/test/join.jl
@@ -1,6 +1,8 @@
 ts1 = TSFrame(rand(DATA_SIZE), index_timetype)
 ts2 = TSFrame(rand(Int(floor(DATA_SIZE/2))), index_timetype[1:Int(floor(DATA_SIZE/2))])
 ts3 = TSFrame(rand(DATA_SIZE), index_timetype)
+ts4 = TSFrame(rand(DATA_SIZE), index_timetype)
+ts5 = TSFrame(rand(DATA_SIZE), index_timetype)
 
 # testing JoinInner/JoinBoth
 ts_innerjoin = join(ts1, ts2, JoinInner)
@@ -28,6 +30,24 @@ ts_multiplejoinboth = join(ts1, ts2, ts3; jointype=JoinBoth)
 @test ts_multiplejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multiplejoinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multiplejoinboth[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
+
+ts_fiveinnerjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinInner)
+@test propertynames(ts_fiveinnerjoins.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
+@test ts_fiveinnerjoins[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
+@test ts_fiveinnerjoins[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fiveinnerjoins[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fiveinnerjoins[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fiveinnerjoins[:, :x1_3] == ts4[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fiveinnerjoins[:, :x1_4] == ts5[1:Int(floor(DATA_SIZE/2)), :x1]
+
+ts_fivejoinboth = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinBoth)
+@test propertynames(ts_fivejoinboth.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
+@test ts_fivejoinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
+@test ts_fivejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fivejoinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fivejoinboth[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fivejoinboth[:, :x1_3] == ts4[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fivejoinboth[:, :x1_4] == ts5[1:Int(floor(DATA_SIZE/2)), :x1]
 
 # testing JoinOuter/JoinAll
 ts_outerjoin = join(ts1, ts2, JoinOuter)
@@ -60,6 +80,24 @@ ts_multiplejoinall = join(ts1, ts2, ts3; jointype=JoinAll)
 @test ts_multiplejoinall[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multiplejoinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
+ts_fiveouterjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinOuter)
+@test propertynames(ts_fiveouterjoins.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
+@test ts_fiveouterjoins[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_fiveouterjoins[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fiveouterjoins[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test ts_fiveouterjoins[:, :x1_3] == ts4[1:DATA_SIZE, :x1]
+@test ts_fiveouterjoins[:, :x1_4] == ts5[1:DATA_SIZE, :x1]
+@test isequal(Vector{Missing}(ts_fiveouterjoins[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+
+ts_fivejoinalls = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinAll)
+@test propertynames(ts_fivejoinalls.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
+@test ts_fivejoinalls[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_fivejoinalls[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fivejoinalls[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test ts_fivejoinalls[:, :x1_3] == ts4[1:DATA_SIZE, :x1]
+@test ts_fivejoinalls[:, :x1_4] == ts5[1:DATA_SIZE, :x1]
+@test isequal(Vector{Missing}(ts_fivejoinalls[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+
 # testing JoinLeft
 ts_joinleft = join(ts1, ts2, JoinLeft)
 @test propertynames(ts_joinleft.coredata) == [:Index, :x1, :x1_1]
@@ -76,6 +114,16 @@ ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=JoinLeft)
 @test ts_multiplejoinleft[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multiplejoinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
+ts_fivejoinlefts = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinLeft)
+@test propertynames(ts_fivejoinlefts.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
+@test ts_fivejoinlefts[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_fivejoinlefts[:, :x1] == ts1[1:DATA_SIZE, :x1]
+@test ts_fivejoinlefts[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test ts_fivejoinlefts[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test ts_fivejoinlefts[:, :x1_3] == ts4[1:DATA_SIZE, :x1]
+@test ts_fivejoinlefts[:, :x1_4] == ts5[1:DATA_SIZE, :x1]
+@test isequal(Vector{Missing}(ts_fivejoinlefts[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+
 # testing JoinRight
 ts_joinright = join(ts1, ts2, JoinRight)
 @test propertynames(ts_joinright.coredata) == [:Index, :x1, :x1_1]
@@ -91,3 +139,14 @@ ts_multiplejoinright = join(ts1, ts2, ts3; jointype=JoinRight)
 @test ts_multiplejoinright[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_multiplejoinright[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 @test ts_multiplejoinright[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+
+ts_fivejoinrights = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinRight)
+@test propertynames(ts_fivejoinrights.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
+@test ts_fivejoinrights[:, :Index] == ts1[1:DATA_SIZE, :Index]
+@test ts_fivejoinrights[1:Int(floor(DATA_SIZE/2)), :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
+@test isequal(Vector{Missing}(ts_fivejoinrights[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+@test ts_fivejoinrights[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
+@test isequal(Vector{Missing}(ts_fivejoinrights[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
+@test ts_fivejoinrights[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
+@test ts_fivejoinrights[:, :x1_3] == ts4[1:DATA_SIZE, :x1]
+@test ts_fivejoinrights[:, :x1_4] == ts5[1:DATA_SIZE, :x1]

--- a/test/join.jl
+++ b/test/join.jl
@@ -15,14 +15,14 @@ ts_joinboth = join(ts1, ts2, JoinBoth)
 @test ts_joinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multipleinnerjoin = join(ts1, ts2, ts3; jointype=JoinInner)
+ts_multipleinnerjoin = join(ts1, ts2, ts3; on=JoinInner)
 @test propertynames(ts_multipleinnerjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multipleinnerjoin[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_multipleinnerjoin[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multipleinnerjoin[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multipleinnerjoin[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multiplejoinboth = join(ts1, ts2, ts3; jointype=JoinBoth)
+ts_multiplejoinboth = join(ts1, ts2, ts3; on=JoinBoth)
 @test propertynames(ts_multiplejoinboth.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_multiplejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -44,7 +44,7 @@ ts_joinall = join(ts1, ts2, JoinAll)
 @test ts_joinall[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=JoinOuter)
+ts_multipleouterjoin = join(ts1, ts2, ts3; on=JoinOuter)
 @test propertynames(ts_multipleouterjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multipleouterjoin[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multipleouterjoin[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -52,7 +52,7 @@ ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=JoinOuter)
 @test ts_multipleouterjoin[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multipleouterjoin[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multiplejoinall = join(ts1, ts2, ts3; jointype=JoinAll)
+ts_multiplejoinall = join(ts1, ts2, ts3; on=JoinAll)
 @test propertynames(ts_multiplejoinall.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinall[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinall[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -68,7 +68,7 @@ ts_joinleft = join(ts1, ts2, JoinLeft)
 @test ts_joinleft[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=JoinLeft)
+ts_multiplejoinleft = join(ts1, ts2, ts3; on=JoinLeft)
 @test propertynames(ts_multiplejoinleft.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinleft[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinleft[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -83,7 +83,7 @@ ts_joinright = join(ts1, ts2, JoinRight)
 @test ts_joinright[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinright[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multiplejoinright = join(ts1, ts2, ts3; jointype=JoinRight)
+ts_multiplejoinright = join(ts1, ts2, ts3; on=JoinRight)
 @test propertynames(ts_multiplejoinright.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinright[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinright[1:Int(floor(DATA_SIZE/2)), :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]

--- a/test/join.jl
+++ b/test/join.jl
@@ -15,14 +15,14 @@ ts_joinboth = join(ts1, ts2, JoinBoth)
 @test ts_joinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multipleinnerjoin = join(ts1, ts2, ts3; on=JoinInner)
+ts_multipleinnerjoin = join(ts1, ts2, ts3; jointype=JoinInner)
 @test propertynames(ts_multipleinnerjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multipleinnerjoin[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_multipleinnerjoin[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multipleinnerjoin[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multipleinnerjoin[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multiplejoinboth = join(ts1, ts2, ts3; on=JoinBoth)
+ts_multiplejoinboth = join(ts1, ts2, ts3; jointype=JoinBoth)
 @test propertynames(ts_multiplejoinboth.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_multiplejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -44,7 +44,7 @@ ts_joinall = join(ts1, ts2, JoinAll)
 @test ts_joinall[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multipleouterjoin = join(ts1, ts2, ts3; on=JoinOuter)
+ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=JoinOuter)
 @test propertynames(ts_multipleouterjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multipleouterjoin[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multipleouterjoin[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -52,7 +52,7 @@ ts_multipleouterjoin = join(ts1, ts2, ts3; on=JoinOuter)
 @test ts_multipleouterjoin[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multipleouterjoin[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multiplejoinall = join(ts1, ts2, ts3; on=JoinAll)
+ts_multiplejoinall = join(ts1, ts2, ts3; jointype=JoinAll)
 @test propertynames(ts_multiplejoinall.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinall[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinall[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -68,7 +68,7 @@ ts_joinleft = join(ts1, ts2, JoinLeft)
 @test ts_joinleft[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multiplejoinleft = join(ts1, ts2, ts3; on=JoinLeft)
+ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=JoinLeft)
 @test propertynames(ts_multiplejoinleft.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinleft[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinleft[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -83,7 +83,7 @@ ts_joinright = join(ts1, ts2, JoinRight)
 @test ts_joinright[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinright[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multiplejoinright = join(ts1, ts2, ts3; on=JoinRight)
+ts_multiplejoinright = join(ts1, ts2, ts3; jointype=JoinRight)
 @test propertynames(ts_multiplejoinright.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinright[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinright[1:Int(floor(DATA_SIZE/2)), :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]

--- a/test/join.jl
+++ b/test/join.jl
@@ -5,33 +5,33 @@ ts4 = TSFrame(rand(DATA_SIZE), index_timetype)
 ts5 = TSFrame(rand(DATA_SIZE), index_timetype)
 
 # testing JoinInner/JoinBoth
-ts_innerjoin = join(ts1, ts2, JoinInner)
+ts_innerjoin = join(ts1, ts2; jointype=:JoinInner)
 @test propertynames(ts_innerjoin.coredata) == [:Index, :x1, :x1_1]
 @test ts_innerjoin[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_innerjoin[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_innerjoin[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_joinboth = join(ts1, ts2, JoinBoth)
+ts_joinboth = join(ts1, ts2; jointype=:JoinBoth)
 @test propertynames(ts_joinboth.coredata) == [:Index, :x1, :x1_1]
 @test ts_joinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_joinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multipleinnerjoin = join(ts1, ts2, ts3; jointype=JoinInner)
+ts_multipleinnerjoin = join(ts1, ts2, ts3; jointype=:JoinInner)
 @test propertynames(ts_multipleinnerjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multipleinnerjoin[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_multipleinnerjoin[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multipleinnerjoin[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multipleinnerjoin[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multiplejoinboth = join(ts1, ts2, ts3; jointype=JoinBoth)
+ts_multiplejoinboth = join(ts1, ts2, ts3; jointype=:JoinBoth)
 @test propertynames(ts_multiplejoinboth.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_multiplejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multiplejoinboth[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_multiplejoinboth[:, :x1_2] == ts3[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_fiveinnerjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinInner)
+ts_fiveinnerjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=:JoinInner)
 @test propertynames(ts_fiveinnerjoins.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
 @test ts_fiveinnerjoins[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_fiveinnerjoins[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -40,7 +40,7 @@ ts_fiveinnerjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinInner)
 @test ts_fiveinnerjoins[:, :x1_3] == ts4[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_fiveinnerjoins[:, :x1_4] == ts5[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_fivejoinboth = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinBoth)
+ts_fivejoinboth = join(ts1, ts2, ts3, ts4, ts5; jointype=:JoinBoth)
 @test propertynames(ts_fivejoinboth.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
 @test ts_fivejoinboth[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_fivejoinboth[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -50,21 +50,21 @@ ts_fivejoinboth = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinBoth)
 @test ts_fivejoinboth[:, :x1_4] == ts5[1:Int(floor(DATA_SIZE/2)), :x1]
 
 # testing JoinOuter/JoinAll
-ts_outerjoin = join(ts1, ts2, JoinOuter)
+ts_outerjoin = join(ts1, ts2; jointype=:JoinOuter)
 @test propertynames(ts_outerjoin.coredata) == [:Index, :x1, :x1_1]
 @test ts_outerjoin[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_outerjoin[:, :x1] == ts1[1:DATA_SIZE, :x1]
 @test ts_outerjoin[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_outerjoin[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_joinall = join(ts1, ts2, JoinAll)
+ts_joinall = join(ts1, ts2; jointype=:JoinAll)
 @test propertynames(ts_joinall.coredata) == [:Index, :x1, :x1_1]
 @test ts_joinall[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_joinall[:, :x1] == ts1[1:DATA_SIZE, :x1]
 @test ts_joinall[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=JoinOuter)
+ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=:JoinOuter)
 @test propertynames(ts_multipleouterjoin.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multipleouterjoin[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multipleouterjoin[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -72,7 +72,7 @@ ts_multipleouterjoin = join(ts1, ts2, ts3; jointype=JoinOuter)
 @test ts_multipleouterjoin[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multipleouterjoin[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multiplejoinall = join(ts1, ts2, ts3; jointype=JoinAll)
+ts_multiplejoinall = join(ts1, ts2, ts3; jointype=:JoinAll)
 @test propertynames(ts_multiplejoinall.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinall[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinall[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -80,7 +80,7 @@ ts_multiplejoinall = join(ts1, ts2, ts3; jointype=JoinAll)
 @test ts_multiplejoinall[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multiplejoinall[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_fiveouterjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinOuter)
+ts_fiveouterjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=:JoinOuter)
 @test propertynames(ts_fiveouterjoins.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
 @test ts_fiveouterjoins[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_fiveouterjoins[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -89,7 +89,7 @@ ts_fiveouterjoins = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinOuter)
 @test ts_fiveouterjoins[:, :x1_4] == ts5[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_fiveouterjoins[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_fivejoinalls = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinAll)
+ts_fivejoinalls = join(ts1, ts2, ts3, ts4, ts5; jointype=:JoinAll)
 @test propertynames(ts_fivejoinalls.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
 @test ts_fivejoinalls[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_fivejoinalls[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -99,14 +99,14 @@ ts_fivejoinalls = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinAll)
 @test isequal(Vector{Missing}(ts_fivejoinalls[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
 # testing JoinLeft
-ts_joinleft = join(ts1, ts2, JoinLeft)
+ts_joinleft = join(ts1, ts2; jointype=:JoinLeft)
 @test propertynames(ts_joinleft.coredata) == [:Index, :x1, :x1_1]
 @test ts_joinleft[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_joinleft[:, :x1] == ts1[1:DATA_SIZE, :x1]
 @test ts_joinleft[1:Int(floor(DATA_SIZE/2)), :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 @test isequal(Vector{Missing}(ts_joinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=JoinLeft)
+ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=:JoinLeft)
 @test propertynames(ts_multiplejoinleft.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinleft[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinleft[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -114,7 +114,7 @@ ts_multiplejoinleft = join(ts1, ts2, ts3; jointype=JoinLeft)
 @test ts_multiplejoinleft[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 @test isequal(Vector{Missing}(ts_multiplejoinleft[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
-ts_fivejoinlefts = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinLeft)
+ts_fivejoinlefts = join(ts1, ts2, ts3, ts4, ts5; jointype=:JoinLeft)
 @test propertynames(ts_fivejoinlefts.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
 @test ts_fivejoinlefts[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_fivejoinlefts[:, :x1] == ts1[1:DATA_SIZE, :x1]
@@ -125,13 +125,13 @@ ts_fivejoinlefts = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinLeft)
 @test isequal(Vector{Missing}(ts_fivejoinlefts[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 
 # testing JoinRight
-ts_joinright = join(ts1, ts2, JoinRight)
+ts_joinright = join(ts1, ts2, jointype=:JoinRight)
 @test propertynames(ts_joinright.coredata) == [:Index, :x1, :x1_1]
 @test ts_joinright[:, :Index] == ts1[1:Int(floor(DATA_SIZE/2)), :Index]
 @test ts_joinright[:, :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
 @test ts_joinright[:, :x1_1] == ts2[1:Int(floor(DATA_SIZE/2)), :x1]
 
-ts_multiplejoinright = join(ts1, ts2, ts3; jointype=JoinRight)
+ts_multiplejoinright = join(ts1, ts2, ts3; jointype=:JoinRight)
 @test propertynames(ts_multiplejoinright.coredata) == [:Index, :x1, :x1_1, :x1_2]
 @test ts_multiplejoinright[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_multiplejoinright[1:Int(floor(DATA_SIZE/2)), :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]
@@ -140,7 +140,7 @@ ts_multiplejoinright = join(ts1, ts2, ts3; jointype=JoinRight)
 @test isequal(Vector{Missing}(ts_multiplejoinright[Int(floor(DATA_SIZE/2)) + 1:DATA_SIZE, :x1_1]), fill(missing, DATA_SIZE - Int(floor(DATA_SIZE/2))))
 @test ts_multiplejoinright[:, :x1_2] == ts3[1:DATA_SIZE, :x1]
 
-ts_fivejoinrights = join(ts1, ts2, ts3, ts4, ts5; jointype=JoinRight)
+ts_fivejoinrights = join(ts1, ts2, ts3, ts4, ts5; jointype=:JoinRight)
 @test propertynames(ts_fivejoinrights.coredata) == [:Index, :x1, :x1_1, :x1_2, :x1_3, :x1_4]
 @test ts_fivejoinrights[:, :Index] == ts1[1:DATA_SIZE, :Index]
 @test ts_fivejoinrights[1:Int(floor(DATA_SIZE/2)), :x1] == ts1[1:Int(floor(DATA_SIZE/2)), :x1]


### PR DESCRIPTION
This PR addresses issue https://github.com/xKDR/TSFrames.jl/issues/40. We have added a method for `join` which takes in a variable number of `TSFrame`s (this number should be at least 2). We have assumed that the `join`s are left associative. To keep the syntax similar to what we already have, we have added the join type as the keyword argument `jointype` (since the variable number of arguments needs to be the final positional argument). For more, please refer to the discussion in https://github.com/xKDR/TSFrames.jl/issues/40.

Corresponding documentation and tests have been added.