### PR TITLE
Adding more permissions to TagBot.

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,7 +8,18 @@ on:
       lookback:
         default: 3
 permissions:
-    contents: write
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Currently, TagBot is throwing the following error: `GitHub returned a 5xx error code`. This PR uses the latest TagBot configuration from the [TagBot](https://github.com/JuliaRegistries/TagBot) repository.