### PR TITLE
Install package from registery

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ extensible at the same time.
 
 ```julia
 julia> using Pkg
-julia> Pkg.add(url="https://github.com/xKDR/TSFrames.jl")
+julia> Pkg.add("TSFrames")
 ```
 
 ## Basic usage


### PR DESCRIPTION
Since the package is registered now, users don't need to supply the URL to install it.