### PR TITLE
New constructors for empty `TSFrame`s.

### DIFF
--- a/src/TSFrame.jl
+++ b/src/TSFrame.jl
@@ -388,3 +388,10 @@ function TSFrame(T::DataType; n::Int=1)
     df.Index = T[]
     TSFrame(df)
 end
+
+# For empty TSFrames
+function TSFrame(T::DataType, cols::Vector{Tuple{DataType, S}}) where S <: Union{Symbol, String}
+    df = DataFrame([colname => type[] for (type, colname) in cols])
+    insertcols!(df, :Index => T[])
+    TSFrame(df)
+end

--- a/src/TSFrame.jl
+++ b/src/TSFrame.jl
@@ -35,6 +35,8 @@ TSFrame(coredata::AbstractVector{T}, index::AbstractVector{V}; colnames=:auto) w
 TSFrame(coredata::AbstractVector{T}; colnames=:auto) where {T}
 TSFrame(coredata::AbstractArray{T,2}; colnames=:auto) where {T}
 TSFrame(coredata::AbstractArray{T,2}, index::AbstractVector{V}; colnames=:auto) where {T, V}
+TSFrame(T::DataType; n::Int=1)
+TSFrame(T::DataType, cols::Vector{Tuple{DataType, S}}) where S <: Union{Symbol, String}
 ```
 
 # Examples
@@ -293,6 +295,15 @@ julia> ts = TSFrame([random(10) random(10)], dates, colnames=[:A, :B]) # columns
  2017-01-08  0.0521332  0.0521332
  2017-01-09  0.26864    0.26864
  2017-01-10  0.108871   0.108871
+
+julia> ts = TSFrame(Int64; n=5) # empty TSFrame with 5 columns of type Any and with Int64 index type
+0×5 TSFrame with Int64 Index
+
+julia> ts = TSFrame(Date, [(Int64, :col1), (String, :col2), (Float64, :col3)]) # empty TSFrame with specific column names and types
+0×3 TSFrame with Date Index
+
+julia> ts = TSFrame(Date, [(Int64, "col1"), (String, "col2"), (Float64, "col3")]) # using strings instead of symbols
+0×3 TSFrame with Date Index
 
 ```
 """

--- a/src/TSFrame.jl
+++ b/src/TSFrame.jl
@@ -35,8 +35,8 @@ TSFrame(coredata::AbstractVector{T}, index::AbstractVector{V}; colnames=:auto) w
 TSFrame(coredata::AbstractVector{T}; colnames=:auto) where {T}
 TSFrame(coredata::AbstractArray{T,2}; colnames=:auto) where {T}
 TSFrame(coredata::AbstractArray{T,2}, index::AbstractVector{V}; colnames=:auto) where {T, V}
-TSFrame(T::DataType; n::Int=1)
-TSFrame(T::DataType, cols::Vector{Tuple{DataType, S}}) where S <: Union{Symbol, String}
+TSFrame(IndexType::DataType; n::Int=1)
+TSFrame(IndexType::DataType, cols::Vector{Tuple{DataType, S}}) where S <: Union{Symbol, String}
 ```
 
 # Examples
@@ -393,16 +393,16 @@ function TSFrame(coredata::AbstractArray{T,2}, index::AbstractVector{V}; colname
     TSFrame(df, index)
 end
 
-function TSFrame(T::DataType; n::Int=1)
+function TSFrame(IndexType::DataType; n::Int=1)
     (n>=1) || throw(DomainError(n, "n should be >= 1"))
     df = DataFrame(fill([],n), :auto)
-    df.Index = T[]
+    df.Index = IndexType[]
     TSFrame(df)
 end
 
 # For empty TSFrames
-function TSFrame(T::DataType, cols::Vector{Tuple{DataType, S}}) where S <: Union{Symbol, String}
+function TSFrame(IndexType::DataType, cols::Vector{Tuple{DataType, S}}) where S <: Union{Symbol, String}
     df = DataFrame([colname => type[] for (type, colname) in cols])
-    insertcols!(df, :Index => T[])
+    insertcols!(df, :Index => IndexType[])
     TSFrame(df)
 end

--- a/test/TSFrame.jl
+++ b/test/TSFrame.jl
@@ -117,6 +117,34 @@ function test_empty_timeframe_cons()
     @test_throws DomainError TSFrame(Int, n=0)
     @test_throws DomainError TSFrame(Date, n=-1)
     @test_throws DomainError TSFrame(Date, n=0)
+
+    # testing empty constructor for specific column names and types
+    ts_empty_int = TSFrame(Int, [(Int, :col1), (Float64, :col2), (String, :col3)])
+    ts_empty_date = TSFrame(Date, [(Int, :col1), (Float64, :col2), (String, :col3)])
+
+    @test size(ts_empty_int)==(0, 3)
+    @test size(ts_empty_date)==(0, 3)
+
+    @test TSFrames.nrow(ts_empty_int)==0
+    @test TSFrames.nrow(ts_empty_date)==0
+
+    @test TSFrames.ncol(ts_empty_int)==3
+    @test TSFrames.ncol(ts_empty_date)==3
+
+    @test propertynames(ts_empty_int.coredata) == [:Index, :col1, :col2, :col3]
+    @test propertynames(ts_empty_date.coredata) == [:Index, :col1, :col2, :col3]
+
+    @test eltype(index(ts_empty_int))==Int
+    @test eltype(index(ts_empty_date))==Date
+
+    @test eltype(ts_empty_int[:, :col1])==Int
+    @test eltype(ts_empty_date[:, :col1])==Int
+
+    @test eltype(ts_empty_int[:, :col2])==Float64
+    @test eltype(ts_empty_date[:, :col2])==Float64
+
+    @test eltype(ts_empty_int[:, :col3])==String
+    @test eltype(ts_empty_date[:, :col3])==String
 end
 
 # Run each test


### PR DESCRIPTION
This PR addresses issue https://github.com/xKDR/TSFrames.jl/issues/132. A new constructor has been added, which takes in the type of `Index` and the names and types of the columns of the resultant `TSFrame`, and creates an empty `TSFrame` object. Corresponding documentation and tests have been added as well.