### PR TITLE
Support pre-sorted data in the `TSFrame` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ As another example of this, consider the following code, which converts a `TimeA
 ```julia
 julia> using TSFrames, MarketData;
 
-julia> TSFrame(MarketData.yahoo(:AAPL))
+julia> TSFrame(MarketData.yahoo(:AAPL); issorted = true)
 10550×6 TSFrame with Date Index
  Index       Open        High        Low         Close       AdjClose    Volume
  Date        Float64     Float64     Float64     Float64     Float64     Float64
@@ -97,6 +97,8 @@ julia> TSFrame(MarketData.yahoo(:AAPL))
  2022-10-14  144.31      144.52      138.19      138.38      138.38      8.85123e7
                                                                  10522 rows omitted
 ```
+
+Since we know that our data is in chronological order, we set the `issorted` keyword argument to the `TSFrame` constructor to `true`, allowing it to skip sorting the input table.
 
 ### Indexing
 ```julia

--- a/test/TSFrame.jl
+++ b/test/TSFrame.jl
@@ -153,6 +153,9 @@ end
     @test !(issorted(unsorted_frame.coredata[!, :Index]))
     sorted_frame = TSFrame(1:1000, unsorted; issorted = false)
     @test issorted(sorted_frame.coredata[!, :Index])
+    unsorted_dataframe = DataFrame(:myind => unsorted)
+    unsorted_tsframe_from_dataframe = TSFrame(unsorted_dataframe; issorted = true)
+    @test unsorted_dataframe[!, :myind] == unsorted_tsframe_from_dataframe.coredata[!, :Index]
 end
 
 # Run each test

--- a/test/TSFrame.jl
+++ b/test/TSFrame.jl
@@ -147,6 +147,14 @@ function test_empty_timeframe_cons()
     @test eltype(ts_empty_date[:, :col3])==String
 end
 
+@testset "issorted in constructor" begin
+    unsorted = randperm(1000)
+    unsorted_frame = TSFrame(1:1000, unsorted; issorted = true)
+    @test !(issorted(unsorted_frame.coredata[!, :Index]))
+    sorted_frame = TSFrame(1:1000, unsorted; issorted = false)
+    @test issorted(sorted_frame.coredata[!, :Index])
+end
+
 # Run each test
 # NOTE: Do not forget to add any new test-function created above
 # otherwise that test won't run.

--- a/test/TSFrame.jl
+++ b/test/TSFrame.jl
@@ -154,7 +154,7 @@ end
     sorted_frame = TSFrame(1:1000, unsorted; issorted = false)
     @test issorted(sorted_frame.coredata[!, :Index])
     unsorted_dataframe = DataFrame(:myind => unsorted)
-    unsorted_tsframe_from_dataframe = TSFrame(unsorted_dataframe; issorted = true)
+    unsorted_tsframe_from_dataframe = TSFrame(unsorted_dataframe, :myind; issorted = true)
     @test unsorted_dataframe[!, :myind] == unsorted_tsframe_from_dataframe.coredata[!, :Index]
 end
 


### PR DESCRIPTION
With this PR, the user can set the `issorted` kwarg to `true`, if this is to be the case.  This indicates to TSFrames that it doesn't need to perform any sorting operations when constructing a `TSFrame`.

This is especially effective when dealing with long datasets (1,000,000+ points).  It's also the first step towards creating an optimized TSFrames join function.