### PR TITLE
More `rename!` methods.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -338,13 +338,29 @@ end
 """
 # Column Rename
 ```julia
-rename!(ts::TSFrame, colnames::AbstractVector{String})
-rename!(ts::TSFrame, colnames::AbstractVector{Symbol})
+rename!(ts::TSFrame, colnames::AbstractVector{String}; makeunique::Bool=false)
+rename!(ts::TSFrame, colnames::AbstractVector{Symbol}; makeunique::Bool=false)
+rename!(ts::TSFrame, (from => to)::Pair...)
+rename!(ts::TSFrame, d::AbstractDict)
+rename!(ts::TSFrame, d::AbstractVector{<:Pair})
+rename!(f::Function, ts::TSFrame)
 ```
 
-Renames columns of `ts` to the values in `colnames`, in order. Input
-is a vector of either Strings or Symbols. The `Index` column name is reserved,
-and `rename!()` will throw an error if `colnames` contains the name `Index`.
+Renames columns of `ts` in-place. The interface is similar to [DataFrames.jl's renaming interface](https://dataframes.juliadata.org/stable/lib/functions/#DataFrames.rename!).
+
+# Arguments
+
+- `ts`: the `TSFrame`.
+- `colnames`: an `AbstractVector` containing `String`s or `Symbol`s. Must be of the same length as the number of non-`Index` columns in `ts`, and cannot contain the string `"Index"` or the symbol `:Index`.
+- `makeunique`: if `false` (which is the default), an error will be raised if `colnames` contains duplicate names. If `true`, then duplicate names will be suffixed with `_i` (`i` starting at `1` for the first duplicate).
+- `d`: an `AbstractDict` or an `AbstractVector` of `Pair`s that maps original names to new names. Cannot map `:Index` to any other column name.
+- `f`: a function which for each non-`Index` column takes the old name as a `String` and returns the new name as a `String`.
+
+If pairs are passed to `rename!` (as positional arguments or as a dictionary or as a vector), then
+
+- `from` can be a `String` or a `Symbol`.
+- `to` can be a `String` or a `Symbol`.
+- Mixing `String`s and `Symbol`s in `from` and `to` is not allowed.
 
 ```jldoctest; setup = :(using TSFrames, DataFrames, Dates, Random)
 julia> ts

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -418,6 +418,8 @@ function rename!(ts::TSFrame,
     return ts
 end
 
+rename!(ts::TSFrame, args::Pair...) = rename!(ts, collect(args))
+
 """
 Internal function to check consistency of the Index of a TSFrame
 object.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -406,6 +406,17 @@ function rename!(ts::TSFrame, args::AbstractVector{Pair{Symbol, Symbol}})
     return ts
 end
 
+function rename!(ts::TSFrame,
+                 args::Union{AbstractVector{<:Pair{Symbol, <:AbstractString}},
+                             AbstractVector{<:Pair{<:AbstractString, Symbol}},
+                             AbstractVector{<:Pair{<:AbstractString, <:AbstractString}},
+                             AbstractDict{Symbol, Symbol},
+                             AbstractDict{Symbol, <:AbstractString},
+                             AbstractDict{<:AbstractString, Symbol},
+                             AbstractDict{<:AbstractString, <:AbstractString}})
+    rename!(ts, [Symbol(from) => Symbol(to) for (from, to) in args])
+    return ts
+end
 
 """
 Internal function to check consistency of the Index of a TSFrame

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -420,6 +420,18 @@ end
 
 rename!(ts::TSFrame, args::Pair...) = rename!(ts, collect(args))
 
+function rename!(f::Function, ts::TSFrame)
+    # check if f maps some non-Index column to Index
+    cols = String.(propertynames(ts.coredata))
+    idx = findall(i -> i != "Index" && f(i) == "Index", cols)
+    if length(idx) > 0
+        throw(ArgumentError("Column name Index not allowed in TSFrame object"))
+    end
+
+    DataFrames.rename!(col -> (col == "Index") ? "Index" : f(col), ts.coredata)
+    return ts
+end
+
 """
 Internal function to check consistency of the Index of a TSFrame
 object.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -382,18 +382,18 @@ Int64  Int64  Int64
      92 rows omitted
 ```
 """
-function rename!(ts::TSFrame, colnames::AbstractVector{String})
-    rename!(ts, Symbol.(colnames))
+function rename!(ts::TSFrame, colnames::AbstractVector{String}; makeunique::Bool=false)
+    rename!(ts, Symbol.(colnames), makeunique=makeunique)
 end
 
-function rename!(ts::TSFrame, colnames::AbstractVector{Symbol})
+function rename!(ts::TSFrame, colnames::AbstractVector{Symbol}; makeunique::Bool=false)
     idx = findall(i -> i == :Index, colnames)
     if length(idx) > 0
         error("Column name `Index` not allowed in TSFrame object")
     end
     cols = copy(colnames)
     insert!(cols, 1, :Index)
-    DataFrames.rename!(ts.coredata, cols)
+    DataFrames.rename!(ts.coredata, cols; makeunique=makeunique)
     return ts
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -362,41 +362,118 @@ If pairs are passed to `rename!` (as positional arguments or as a dictionary or 
 - `to` can be a `String` or a `Symbol`.
 - Mixing `String`s and `Symbol`s in `from` and `to` is not allowed.
 
-```jldoctest; setup = :(using TSFrames, DataFrames, Dates, Random)
-julia> ts
-(100 x 2) TSFrame with Int64 Index
+```jldoctest; setup = :(using TSFrames, DataFrames, Dates)
+julia> ts = TSFrame(DataFrame(Index=Date(2012, 1, 1):Day(1):Date(2012, 1, 10), x1=1:10, x2=11:20))
+10×2 TSFrame with Date Index
+ Index       x1     x2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
 
- Index  x1     x2
- Int64  Int64  Int64
-─────────────────────
-     1      2      1
-     2      3      2
-     3      4      3
-     4      5      4
-   ⋮      ⋮      ⋮
-    97     98     97
-    98     99     98
-    99    100     99
-   100    101    100
-      92 rows omitted
+julia> TSFrames.rename!(ts, ["X1", "X2"])
+ 10×2 TSFrame with Date Index
+ Index       X1     X2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
 
-julia> rename!(ts, ["Col1", "Col2"])
-(100 x 2) TSFrame with Int64 Index
+julia> TSFrames.rename!(ts, [:x1, :x2])
+10×2 TSFrame with Date Index
+ Index       x1     x2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
 
-Index  Col1   Col2
-Int64  Int64  Int64
-─────────────────────
-    1      2      1
-    2      3      2
-    3      4      3
-    4      5      4
-  ⋮      ⋮      ⋮
-   97     98     97
-   98     99     98
-   99    100     99
-  100    101    100
-     92 rows omitted
-```
+julia> TSFrames.rename!(ts, :x1 => :X1, :x2 => :X2)
+10×2 TSFrame with Date Index
+ Index       X1     X2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
+
+julia> TSFrames.rename!(ts, Dict("X1" => :x1, "X2" => :x2))
+ 10×2 TSFrame with Date Index
+ Index       x1     x2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
+
+julia> TSFrames.rename!(ts, [:x1 => "X1", :x2 => "X2"])
+10×2 TSFrame with Date Index
+ Index       X1     X2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
+
+julia> TSFrames.rename(lowercase, ts)
+10×2 TSFrame with Date Index
+ Index       x1     x2
+ Date        Int64  Int64
+──────────────────────────
+ 2012-01-01      1     11
+ 2012-01-02      2     12
+ 2012-01-03      3     13
+ 2012-01-04      4     14
+ 2012-01-05      5     15
+ 2012-01-06      6     16
+ 2012-01-07      7     17
+ 2012-01-08      8     18
+ 2012-01-09      9     19
+ 2012-01-10     10     20
 """
 function rename!(ts::TSFrame, colnames::AbstractVector{String}; makeunique::Bool=false)
     rename!(ts, Symbol.(colnames), makeunique=makeunique)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -482,7 +482,7 @@ end
 function rename!(ts::TSFrame, colnames::AbstractVector{Symbol}; makeunique::Bool=false)
     idx = findall(i -> i == :Index, colnames)
     if length(idx) > 0
-        error("Column name `Index` not allowed in TSFrame object")
+        throw(ArgumentError("Column name Index not allowed in TSFrame object"))
     end
     cols = copy(colnames)
     insert!(cols, 1, :Index)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -397,6 +397,16 @@ function rename!(ts::TSFrame, colnames::AbstractVector{Symbol})
     return ts
 end
 
+function rename!(ts::TSFrame, args::AbstractVector{Pair{Symbol, Symbol}})
+    idx = findall(i -> i == :Index, [pair.first for pair in args])
+    if length(idx) > 0
+        throw(ArgumentError("Column name Index not allowed in TSFrame object"))
+    end
+    DataFrames.rename!(ts.coredata, args)
+    return ts
+end
+
+
 """
 Internal function to check consistency of the Index of a TSFrame
 object.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -491,10 +491,12 @@ function rename!(ts::TSFrame, colnames::AbstractVector{Symbol}; makeunique::Bool
 end
 
 function rename!(ts::TSFrame, args::AbstractVector{Pair{Symbol, Symbol}})
-    idx = findall(i -> i == :Index, [pair.first for pair in args])
+    # should not be able to map Index to anything or map any other column to Index
+    idx = findall(pair -> pair.first == :Index || pair.second == :Index, [pair for pair in args])
     if length(idx) > 0
-        throw(ArgumentError("Column name Index not allowed in TSFrame object"))
+        throw(ArgumentError("Cannot change name of Index and column name Index not allowed in TSFrame object"))
     end
+
     DataFrames.rename!(ts.coredata, args)
     return ts
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -108,3 +108,45 @@ TSFrames.rename!(ts, duplicate_names, makeunique=true)
 # rename!(ts::TSFrame, colnames::AbstractVector{Symbol}; makeunique=true)
 TSFrames.rename!(ts, Symbol.(duplicate_names), makeunique=true)
 @test isequal(propertynames(ts.coredata), vcat([:Index], [:x1], Symbol.(["x1_" * string(i) for i in 1:NUM_COLUMNS - 1])))
+
+# rename!(ts::TSFrame, args::AbstractVector{<:Pair})
+pairs_sym_sym = [Symbol("x" * string(i)) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS]
+pairs_sym_string = [Symbol("x" * string(i)) => "X" * string(i) for i in 1:NUM_COLUMNS]
+pairs_string_sym = ["x" * string(i) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS]
+pairs_string_string = ["x" * string(i) => "X" * string(i) for i in 1:NUM_COLUMNS]
+rand_index = random(1:NUM_COLUMNS)
+
+## Symbol => Symbol
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_sym_sym)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## Symbol => String
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_sym_string)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## String => Symbol
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_string_sym)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## String => String
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_string_string)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## cannot map Index to any other name or map any other column to Index
+@test_throws ArgumentError TSFrames.rename!(ts, vcat([:Index => :nonIndex], pairs_sym_sym))
+@test_throws ArgumentError TSFrames.rename!(ts, vcat([:Index => "nonIndex"], pairs_sym_string))
+@test_throws ArgumentError TSFrames.rename!(ts, vcat(["Index" => :nonIndex], pairs_string_sym))
+@test_throws ArgumentError TSFrames.rename!(ts, vcat(["nonIndex" => "nonIndex"], pairs_string_string))
+
+pairs_sym_sym[rand_index] = Symbol("x" * string(rand_index)) => :Index
+pairs_sym_string[rand_index] = Symbol("x" * string(rand_index)) => "Index"
+pairs_string_sym[rand_index] = "x" * string(rand_index) => :Index
+pairs_string_string[rand_index] = "x" * string(rand_index) => "Index"
+@test_throws ArgumentError TSFrames.rename!(ts, pairs_sym_sym)
+@test_throws ArgumentError TSFrames.rename!(ts, pairs_sym_string)
+@test_throws ArgumentError TSFrames.rename!(ts, pairs_string_sym)
+@test_throws ArgumentError TSFrames.rename!(ts, pairs_string_string)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -177,3 +177,28 @@ ts = TSFrame(Date; n=NUM_COLUMNS)
 TSFrames.rename!(ts, dict_string_string)
 @test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
 
+# rename!(ts::TSFrame, (from => to)::Pair...)
+pairs_sym_sym = [Symbol("x" * string(i)) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS]
+pairs_sym_string = [Symbol("x" * string(i)) => "X" * string(i) for i in 1:NUM_COLUMNS]
+pairs_string_sym = ["x" * string(i) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS]
+pairs_string_string = ["x" * string(i) => "X" * string(i) for i in 1:NUM_COLUMNS]
+
+## Symbol => Symbol
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_sym_sym...)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## Symbol => String
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_sym_string...)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## String => Symbol
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_string_sym...)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## String => String
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, pairs_string_string...)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -109,7 +109,7 @@ TSFrames.rename!(ts, duplicate_names, makeunique=true)
 TSFrames.rename!(ts, Symbol.(duplicate_names), makeunique=true)
 @test isequal(propertynames(ts.coredata), vcat([:Index], [:x1], Symbol.(["x1_" * string(i) for i in 1:NUM_COLUMNS - 1])))
 
-# rename!(ts::TSFrame, args::AbstractVector{<:Pair})
+# rename!(ts::TSFrame, d::AbstractVector{<:Pair})
 pairs_sym_sym = [Symbol("x" * string(i)) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS]
 pairs_sym_string = [Symbol("x" * string(i)) => "X" * string(i) for i in 1:NUM_COLUMNS]
 pairs_string_sym = ["x" * string(i) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS]
@@ -150,3 +150,30 @@ pairs_string_string[rand_index] = "x" * string(rand_index) => "Index"
 @test_throws ArgumentError TSFrames.rename!(ts, pairs_sym_string)
 @test_throws ArgumentError TSFrames.rename!(ts, pairs_string_sym)
 @test_throws ArgumentError TSFrames.rename!(ts, pairs_string_string)
+
+# rename!(ts::TSFrame, d::AbstractDict)
+dict_sym_sym = Dict([Symbol("x" * string(i)) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS])
+dict_sym_string = Dict([Symbol("x" * string(i)) => "X" * string(i) for i in 1:NUM_COLUMNS])
+dict_string_sym = Dict(["x" * string(i) => Symbol("X" * string(i)) for i in 1:NUM_COLUMNS])
+dict_string_string = Dict(["x" * string(i) => "X" * string(i) for i in 1:NUM_COLUMNS])
+
+## Symbol => Symbol
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, dict_sym_sym)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## Symbol => String
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, dict_sym_string)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## String => Symbol
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, dict_string_sym)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+## String => String
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(ts, dict_string_string)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -202,3 +202,8 @@ TSFrames.rename!(ts, pairs_string_sym...)
 ts = TSFrame(Date; n=NUM_COLUMNS)
 TSFrames.rename!(ts, pairs_string_string...)
 @test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))
+
+# rename!(f::Function, ts::TSFrame)
+ts = TSFrame(Date; n=NUM_COLUMNS)
+TSFrames.rename!(uppercase, ts)
+@test isequal(propertynames(ts.coredata), vcat([:Index], Symbol.("X" * string(i) for i in 1:NUM_COLUMNS)))


### PR DESCRIPTION
This PR implements more `rename!` methods, inspired from [DataFrames.jl's renaming interface](https://dataframes.juliadata.org/stable/lib/functions/#DataFrames.rename!). 

Closes #61.