### PR TITLE
Push preview builds of docs on PRs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,4 +27,5 @@ deploydocs(;
     repo="github.com/xKDR/TSFrames.jl",
     devbranch="main",
     target = "build",
+    push_preview = true,
 )


### PR DESCRIPTION
This allows PRs from known contributors to have their docs hosted at `xkdr.github.io/TSFrames.jl/previews/PR$(PR_NUMBER)`, which helps inspect the output of a change in docs.