### PR TITLE
Add Indicators.jl functionality with TSFrames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.0"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Indicators = "70c4c096-89a6-5ec6-8236-da8aa3bd86fd"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RollingFunctions = "b0e4dd01-7b14-53d8-9b45-175a3e362653"

--- a/src/TSFrames.jl
+++ b/src/TSFrames.jl
@@ -1,6 +1,6 @@
 module TSFrames
 
-using DataFrames, Dates, ShiftedArrays, RecipesBase, RollingFunctions, Tables
+using DataFrames, Dates, ShiftedArrays, RecipesBase, RollingFunctions, Tables, Indicators
 
 import Base.convert
 import Base.diff
@@ -75,7 +75,9 @@ export TSFrame,
     to_nanoseconds,
     vcat,
     DataFrame,
-    Date
+    Date,
+    sma,
+    runmean
 
 include("TSFrame.jl")
 include("utils.jl")
@@ -97,5 +99,6 @@ include("to_period.jl")
 include("vcat.jl")
 include("broadcasting.jl")
 include("tables.jl")
+include("indicators.jl")
 
 end                             # END module TSFrames

--- a/src/indicators.jl
+++ b/src/indicators.jl
@@ -1,0 +1,4 @@
+# Methods for porting Indicators.jl functions to TSFrame objects from TSFrames.jl package
+# See their respective documentation on Indicators.jl
+runmean(X::TSFrame, x::Symbol; args...) = TSFrame(Indicators.runmean(X[:,x]; args...))
+sma(X::TSFrame, x::Symbol; args...) = TSFrame(Indicators.sma(X[:,x]; args...))

--- a/test/indicators.jl
+++ b/test/indicators.jl
@@ -1,0 +1,10 @@
+using MarketData
+
+@testset "indicators_integration" begin
+    sp500 = TSFrame(MarketData.yahoo("^GSPC"))
+    date_from = Date(2021, 03, 1)
+    date_to = Date(2023, 03, 1)
+    sp500_2y = TSFrames.subset(sp500, date_from, date_to)
+    @test sma(sp500_2y, :AdjClose) |> typeof == TSFrame
+    @test runmean(sp500_2y, :Close) |> typeof == TSFrame 
+end


### PR DESCRIPTION
Been looking to use methods defined in Indicators.jl with TSFrame objects. Since Indicators.jl defines its methods using simple `AbstractArray` and `Matrix` types, it is relatively easy to integrate the two packages.

I tried integrating the `runmean` and `sma` (simple moving average) method with TSFrames, and its relatively easy to integrate. 