### PR TITLE
Dropping Julia requirement to v1.6 (LTS)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ RollingFunctions = "0.6.2, 0.7"
 ShiftedArrays = "1.0.0, 2"
 StatsBase = "0.33"
 Tables = "1"
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ RollingFunctions = "0.6.2, 0.7"
 ShiftedArrays = "1.0.0, 2"
 StatsBase = "0.33"
 Tables = "1"
-julia = "1.7"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
If there is no particular reason for Julia v1.7, drop to v1.6 is requested.